### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ http://www.getfloop.com/support
 
 ### Version 2.0 - 2014-10-31
 - new version of the parental gate
-- Note that this version requires XCode 6.
+- Note that this version requires Xcode 6.
 
 ### Version 1.9.2.4 - 2014-10-09
 - fixed potential symbol conflict bug.


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
